### PR TITLE
View opponent boards

### DIFF
--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -3,8 +3,15 @@ import BoardRow from './BoardRow';
 import { boardState } from '../recoil_state';
 import { useRecoilValue } from 'recoil';
 
-const Board = ({ difficulty, revealTile }: BoardAttributes) => {
-  let board = useRecoilValue(boardState);
+const Board = ({
+  difficulty,
+  revealTile,
+  board,
+  viewOnly,
+}: BoardAttributes) => {
+  if (board === undefined) {
+    board = useRecoilValue(boardState);
+  }
   // let size = difficulty === 0 ? 8 : difficulty === 1 ? 14 : 20;
   // let board: CellAttributes[][] = new Array(size)
   //   .fill({ hidden: true, value: 0 })
@@ -26,7 +33,15 @@ const Board = ({ difficulty, revealTile }: BoardAttributes) => {
   return (
     <>
       {board.map((row: CellAttributes[], idx: number) => {
-        return <BoardRow key={idx} x={idx} row={row} revealTile={revealTile} />;
+        return (
+          <BoardRow
+            key={idx}
+            x={idx}
+            row={row}
+            revealTile={revealTile}
+            viewOnly={viewOnly}
+          />
+        );
       })}
     </>
   );

--- a/client/src/components/BoardRow.tsx
+++ b/client/src/components/BoardRow.tsx
@@ -5,9 +5,10 @@ type Props = {
   x: number;
   row: CellAttributes[];
   revealTile: (x: number, y: number) => void;
+  viewOnly: boolean;
 };
 
-const BoardRow = ({ x, row, revealTile }: Props) => {
+const BoardRow = ({ x, row, revealTile, viewOnly }: Props) => {
   return (
     <div style={{ display: 'flex' }}>
       {row.map((cell: CellAttributes, idx: number) => {
@@ -19,6 +20,7 @@ const BoardRow = ({ x, row, revealTile }: Props) => {
             hidden={cell.hidden}
             value={cell.value}
             revealTile={revealTile}
+            viewOnly={viewOnly}
           />
         );
       })}

--- a/client/src/components/Cell.tsx
+++ b/client/src/components/Cell.tsx
@@ -14,10 +14,10 @@ type Props = {
   hidden: boolean;
   value: number;
   revealTile: (x: number, y: number) => void;
+  viewOnly: boolean;
 };
 
-const Cell = ({ x, y, hidden, value, revealTile }: Props) => {
-  let board = useRecoilValue(boardState);
+const Cell = ({ x, y, hidden, value, revealTile, viewOnly }: Props) => {
   const [clearFlags, setClearFlags] = useRecoilState(clearFlagsState);
   const Item = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
@@ -25,10 +25,10 @@ const Cell = ({ x, y, hidden, value, revealTile }: Props) => {
     padding: theme.spacing(1),
     textAlign: 'center',
     color: theme.palette.text.secondary,
-    height: '2rem',
-    width: '2rem',
+    height: viewOnly === false ? '1.8rem' : '1rem',
+    width: viewOnly === false ? '1.8rem' : '1rem',
     borderRadius: '0',
-    fontSize: '1.3rem',
+    fontSize: viewOnly === false ? '1.3rem' : '0.8rem',
   }));
 
   const [cell, setCell] = useState<CellState | number>(CellState.HIDDEN);
@@ -44,7 +44,7 @@ const Cell = ({ x, y, hidden, value, revealTile }: Props) => {
     } else if (cell !== CellState.FLAGGED) {
       setCell(CellState.HIDDEN);
     }
-  }, [board]);
+  }, [value, hidden]);
 
   useEffect(() => {
     if (hidden === true && cell === CellState.FLAGGED) {
@@ -54,6 +54,13 @@ const Cell = ({ x, y, hidden, value, revealTile }: Props) => {
 
   const handleLeftClick = () => {
     if (cell !== CellState.FLAGGED) {
+      // Update the cell
+      hidden = false;
+      if (value === -1) {
+        setCell(CellState.MINE);
+      } else {
+        setCell(value);
+      }
       revealTile(x, y);
     }
   };
@@ -66,23 +73,40 @@ const Cell = ({ x, y, hidden, value, revealTile }: Props) => {
     } else if (hidden) setCell(CellState.FLAGGED);
   };
 
-  return (
-    <Button
-      variant="text"
-      onClick={handleLeftClick}
-      onContextMenu={(e) => {
-        handleRightClick(e);
-      }}
-      sx={{
-        padding: '0',
-        minWidth: '0',
-        border: '1px black solid',
-        borderRadius: 0,
-      }}
-    >
-      <Item>{cell}</Item>
-    </Button>
-  );
+  if (viewOnly === false) {
+    return (
+      <Button
+        variant="text"
+        onClick={handleLeftClick}
+        onContextMenu={(e) => {
+          handleRightClick(e);
+        }}
+        sx={{
+          padding: '0',
+          minWidth: '0',
+          border: '1px black solid',
+          borderRadius: 0,
+        }}
+      >
+        <Item>{cell}</Item>
+      </Button>
+    );
+  } else {
+    return (
+      <Button
+        variant="text"
+        disabled
+        sx={{
+          padding: '0',
+          minWidth: '0',
+          border: '1px black solid',
+          borderRadius: 0,
+        }}
+      >
+        <Item>{cell}</Item>
+      </Button>
+    );
+  }
 };
 
 export default Cell;

--- a/client/src/components/GameVersus.tsx
+++ b/client/src/components/GameVersus.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import './css/GameVersus.css';
+import Board from './Board';
+import { BoardAttributes, CellAttributes } from './Helpers';
+import { roomInfoState, RoomInfo } from '../recoil_state';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+type GameAttributes = {
+  boards: Record<string, CellAttributes[][]>;
+  difficulty: number;
+  revealTile: (x: number, y: number) => void;
+};
+
+const GameVersus = ({ difficulty, revealTile, boards }: GameAttributes) => {
+  let roomInfo = useRecoilValue(roomInfoState);
+  useEffect(() => {
+    console.log('yo');
+    console.log(boards);
+    return;
+  }, [boards]);
+  return (
+    <div>
+      <div className="boards">
+        <div className="mainBoard">
+          <Board
+            difficulty={difficulty}
+            revealTile={revealTile}
+            viewOnly={false}
+          />
+        </div>
+        <div className="otherBoards">
+          {Object.keys(boards).map((username, index) => {
+            if (username !== roomInfo.username) {
+              return (
+                <div className="otherBoard">
+                  <h4>{username}</h4>
+                  <Board
+                    key={index}
+                    difficulty={difficulty}
+                    revealTile={revealTile}
+                    viewOnly={true}
+                    board={boards[username]}
+                  />
+                </div>
+              );
+            }
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GameVersus;

--- a/client/src/components/GameVersus.tsx
+++ b/client/src/components/GameVersus.tsx
@@ -28,24 +28,28 @@ const GameVersus = ({ difficulty, revealTile, boards }: GameAttributes) => {
             viewOnly={false}
           />
         </div>
-        <div className="otherBoards">
-          {Object.keys(boards).map((username, index) => {
-            if (username !== roomInfo.username) {
-              return (
-                <div className="otherBoard">
-                  <h4>{username}</h4>
-                  <Board
-                    key={index}
-                    difficulty={difficulty}
-                    revealTile={revealTile}
-                    viewOnly={true}
-                    board={boards[username]}
-                  />
-                </div>
-              );
-            }
-          })}
-        </div>
+        {Object.keys(boards).length > 1 ? (
+          <div className="otherBoards">
+            {Object.keys(boards).map((username, index) => {
+              if (username !== roomInfo.username) {
+                return (
+                  <div className="otherBoard">
+                    <h4>{username}</h4>
+                    <Board
+                      key={index}
+                      difficulty={difficulty}
+                      revealTile={revealTile}
+                      viewOnly={true}
+                      board={boards[username]}
+                    />
+                  </div>
+                );
+              }
+            })}
+          </div>
+        ) : (
+          <></>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/Helpers.tsx
+++ b/client/src/components/Helpers.tsx
@@ -6,6 +6,8 @@ export type CellAttributes = {
 };
 
 export type BoardAttributes = {
+  viewOnly: boolean;
+  board?: CellAttributes[][];
   difficulty: number;
   revealTile: (x: number, y: number) => void;
 };

--- a/client/src/components/Rooms.tsx
+++ b/client/src/components/Rooms.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, createContext } from 'react';
 import { TextField, Button, imageListItemBarClasses } from '@mui/material';
 import './css/Rooms.css';
 import Board from './Board';
+import GameVersus from './GameVersus';
 import TitleText from './TitleText';
 import io from 'socket.io-client';
 import { BoardAttributes, CellAttributes } from './Helpers';
@@ -22,6 +23,7 @@ const Rooms = () => {
   const [firstMove, setFirstMove] = useState<boolean>(true);
   const [clearFlags, setClearFlags] = useRecoilState(clearFlagsState);
   const [board, setBoard] = useRecoilState(boardState);
+  const [boards, setBoards] = useState<Record<string, CellAttributes[][]>>({});
 
   useEffect(() => {
     socket.on('connect', () => {
@@ -43,10 +45,14 @@ const Rooms = () => {
       console.log('ERROR: ' + message);
     });
 
-    socket.on('boards', (boards) => {
+    socket.on('boards', (boards, sender) => {
       boards = JSON.parse(boards);
       console.log(boards[roomInfo.username]);
-      setBoard(boards[roomInfo.username]);
+      console.log(sender);
+      if (sender === roomInfo.username) {
+        setBoard(boards[roomInfo.username]);
+      }
+      setBoards(boards);
     });
 
     socket.on('game', (condition) => {
@@ -164,7 +170,7 @@ const Rooms = () => {
           )}
         </>
       ) : (
-        <Board difficulty={0} revealTile={revealTile} />
+        <GameVersus difficulty={0} revealTile={revealTile} boards={boards} />
       )}
     </div>
   );

--- a/client/src/components/css/GameVersus.css
+++ b/client/src/components/css/GameVersus.css
@@ -1,0 +1,30 @@
+body {
+  background-color: white;
+  color: black;
+}
+
+.boards {
+  display: flex;
+  gap: 10rem;
+  justify-content: center;
+  margin-right: -12rem;
+  margin-left: -12rem;
+}
+
+.mainBoard {
+  margin: auto;
+}
+
+.otherBoards {
+  height: 50rem;
+  display: flex;
+  overflow-y: scroll;
+  flex-direction: column;
+  gap: 2rem;
+  border: solid;
+  background: rgb(209, 130, 32);
+}
+
+.otherBoard {
+  margin: 1rem;
+}

--- a/server/src/sockets/gameHandler.ts
+++ b/server/src/sockets/gameHandler.ts
@@ -35,11 +35,11 @@ const registerGameHandlers = (io: Server<DefaultEventsMap, DefaultEventsMap, Def
     if (rooms[roomName][socket.username][x][y].value === -1) {
       socket.emit("game", "bomb");
       rooms[roomName][socket.username] = createBoard(1);
-      socket.emit("boards", JSON.stringify(rooms[roomName]));
+      io.to(roomName).emit("boards", JSON.stringify(rooms[roomName]), socket.username);
       return;
     }
     rooms[roomName][socket.username] = unCoverTile(rooms[roomName][socket.username], x, y);
-    socket.emit("boards", JSON.stringify(rooms[roomName]));
+    io.to(roomName).emit("boards", JSON.stringify(rooms[roomName]), socket.username);
     if (isWin(rooms[roomName][socket.username]) === true) {
       console.log(`${socket.username} has won!`);
       socket.emit("game", "win");
@@ -56,7 +56,7 @@ const registerGameHandlers = (io: Server<DefaultEventsMap, DefaultEventsMap, Def
       return;
     }
     console.log(rooms[roomName]);
-    socket.to(roomName).emit("boards", rooms[roomName]);
+    io.to(roomName).emit("boards", rooms[roomName], socket.username);
   }
 
   socket.on("game:revealTile", revealTile);

--- a/server/src/sockets/roomHandler.ts
+++ b/server/src/sockets/roomHandler.ts
@@ -27,7 +27,7 @@ const registerRoomHandlers = (io: Server<DefaultEventsMap, DefaultEventsMap, Def
     rooms[roomName] = {};
     rooms[roomName][socket.username] = createBoard(1);
     console.log("creating room")
-    socket.emit("boards", JSON.stringify(rooms[roomName]));
+    io.to(roomName).emit("boards", JSON.stringify(rooms[roomName]), socket.username);
   }
 
   const joinRoom = (roomName: string) => {
@@ -57,14 +57,14 @@ const registerRoomHandlers = (io: Server<DefaultEventsMap, DefaultEventsMap, Def
       console.log(`${socket.username} has reconnected`);
       socket.join(roomName);
       socket.emit("game-reconnect");
-      socket.emit("boards", JSON.stringify(rooms[roomName]));
+      io.to(socket.roomName).emit("boards", JSON.stringify(rooms[roomName]), socket.username);
       return;
     }
     console.log("joining room")
     rooms[roomName][socket.username] = createBoard(1);
     socket.join(roomName);
     socket.roomName = roomName;
-    socket.emit("boards", JSON.stringify(rooms[roomName]));
+    io.to(roomName).emit("boards", JSON.stringify(rooms[roomName]), socket.username);
   }
 
   const disconnect = () => {


### PR DESCRIPTION
Updated game room so that it shows the board of opponent players. The opponent boards are view only and cannot be interacted with. The player board also updates locally, so the time it takes to reveal the tiles is reduced. 

But this is sometimes buggy so all board updates should be done locally (in future commits hopefully).